### PR TITLE
handle copy error in merger

### DIFF
--- a/merger/merger.go
+++ b/merger/merger.go
@@ -107,8 +107,13 @@ func merge(outfile string, rfields, files []string) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		copyFromFile(inf, stat.Size(), writer, fileSchema[file])
-		inf.Close()
+		if err := copyFromFile(inf, stat.Size(), writer, fileSchema[file]); err != nil {
+			inf.Close()
+			log.Fatal(err)
+		}
+		if err := inf.Close(); err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	if err := writer.Close(); err != nil {


### PR DESCRIPTION
## Summary
- handle error returned from copyFromFile when merging parquet files

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68982fc89fd883219033c73b76851c89